### PR TITLE
fix: index error when there are no commits

### DIFF
--- a/pull_request_codecommit/__init__.py
+++ b/pull_request_codecommit/__init__.py
@@ -22,9 +22,15 @@ def main(repository_path: Optional[str]) -> None:
     click.echo(f"Repo: {repo.repository_name}")
     click.echo(f"Branch: {repo.branch}")
     click.echo()
-    title, description = repo.pull_request_information()
+    pull_request = repo.pull_request_information()
 
-    message = click.edit(f"{title}\n\n{description}")
+    if not pull_request:
+        click.echo(
+            f"There are no differences between {repo.destination} and {repo.branch}!"
+        )
+        exit(0)
+
+    message = click.edit(f"{pull_request[0]}\n\n{pull_request[1]}")
 
     if message is None:
         raise click.ClickException("Pull request was not created")

--- a/pull_request_codecommit/git/commits.py
+++ b/pull_request_codecommit/git/commits.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 import re
 
 from .commit import Commit
@@ -26,8 +26,8 @@ class Commits:
         self.__commits.reverse()
 
     @property
-    def first(self) -> Commit:
-        return self.__commits[0]
+    def first(self) -> Optional[Commit]:
+        return self.__commits[0] if self.__commits else None
 
     def __iter__(self):
         """

--- a/pull_request_codecommit/repository.py
+++ b/pull_request_codecommit/repository.py
@@ -75,9 +75,12 @@ class Repository:
         destination = self.__config("destination_branch")
         return destination if destination else ""
 
-    def pull_request_information(self) -> Tuple[str, str]:
+    def pull_request_information(self) -> Optional[Tuple[str, str]]:
         title_postfix = ""
         commits = self.__git.get_commit_messages(destination_branch=self.destination)
+
+        if not commits.first:
+            return None
 
         issues = ", ".join(commits.issues)
         description = list(map(lambda commit: commit.message.subject, commits))

--- a/tests/test_git_client.py
+++ b/tests/test_git_client.py
@@ -116,8 +116,28 @@ def test_get_commit_messages(
     client = Client(path)
 
     commits = client.get_commit_messages("main")
+
     first: Commit = next(commits)
     second: Commit = next(commits)
 
+    assert first == commits.first
     assert first.message.subject == "feat: my first commit"
     assert second.message.subject == "feat: my second commit"
+
+
+@patch("pull_request_codecommit.git.client.subprocess.run")
+@patch("pull_request_codecommit.git.client.os.path.isdir")
+def test_get_no_commit_messages(mock_isdir: MagicMock, mock_run: MagicMock) -> None:
+    mock_isdir.return_value = True
+
+    def execute(parameters, cwd, stdout):
+        assert -1 == stdout
+        mock_stdout = MagicMock()
+        mock_stdout.stdout = bytes("", "utf-8")
+        return mock_stdout
+
+    mock_run.side_effect = execute
+    client = Client("my-path")
+
+    commits = client.get_commit_messages("main")
+    assert commits.first is None


### PR DESCRIPTION
**Issue #, if available:** #8

## Description of changes:

By returning a None when there are no commits we can detect gracefully.

****

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
