### PR TITLE
fix: repo name remote contains profile

### DIFF
--- a/pull_request_codecommit/git/remote.py
+++ b/pull_request_codecommit/git/remote.py
@@ -42,7 +42,7 @@ class Remote:
     @property
     def name(self) -> str:
         if not self.__name:
-            name = self.__regex(r"(\/\/|@)(.*)$", 2)
+            name = self.__regex(r"(\/\/|.*@)(.*)$", 2)
 
             if name:
                 self.__name = name

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from pull_request_codecommit.repository import Repository
+
+
+@pytest.mark.parametrize(
+    "region, profile, repository",
+    [
+        ("eu-west-1", "my-profile", "my-repository"),
+        ("eu-central-1", "my-other-profile", "my-other-repository"),
+    ],
+)
+@patch("pull_request_codecommit.repository.GitClient")
+def test_remote(
+    mock_git_client: MagicMock, region: str, profile: str, repository: str
+) -> None:
+    mock_git_client.return_value.remote.return_value = (
+        f"codecommit::{region}://{profile}@{repository}"
+    )
+    repo = Repository("/my/repository")
+    assert repo.remote.region == region
+    assert repo.remote.profile == profile
+    assert repo.remote.name == repository


### PR DESCRIPTION
**Issue #, if available:** #11

## Description of changes:

When the remote contains a profile it was appended to the repository name. This was caused by #11.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
