### PR TITLE
feat: use full description when we only have 1 commit

### DIFF
--- a/pull_request_codecommit/__init__.py
+++ b/pull_request_codecommit/__init__.py
@@ -36,7 +36,7 @@ def main(repository_path: Optional[str]) -> None:
         raise click.ClickException("Pull request was not created")
 
     title = message.splitlines()[0]
-    description = "\n".join(message.splitlines()[1:])
+    description = "\n".join(message.splitlines()[1:]).lstrip("\n")
     link = repo.create_pull_request(title, description)
     click.echo(f"Please review/approve: {link}")
     click.echo()

--- a/pull_request_codecommit/aws/client.py
+++ b/pull_request_codecommit/aws/client.py
@@ -54,6 +54,8 @@ class Client:
             "--targets",
             f"repositoryName={repository}, sourceReference={source}, destinationReference={destination}",
         ]
+        # print(command)
+        # return {"pullRequestId": 1}
         response = self.__execute(command)
         data = json.loads(response)
         return data.get("pullRequest")

--- a/pull_request_codecommit/git/commits.py
+++ b/pull_request_codecommit/git/commits.py
@@ -40,6 +40,9 @@ class Commits:
         self.__index += 1
         return item
 
+    def __len__(self) -> int:
+        return len(self.__commits)
+
     @property
     def issues(self) -> List[str]:
         return list(

--- a/pull_request_codecommit/git/message.py
+++ b/pull_request_codecommit/git/message.py
@@ -1,4 +1,5 @@
 import re
+from typing import List
 
 
 class Message:
@@ -14,20 +15,33 @@ class Message:
         for line in iter(message.splitlines()):
             lines.append(line.strip(" "))
 
-        self.__lines = list(filter(None, lines))
-        self.__message = "\n".join(self.__lines)
+        self.__issue: str = ""
+        self.__lines: List[str] = list(filter(None, lines))
+
+        if "issue" in self.__lines[-1].lower():
+            self.__detect_issue(self.__lines.pop())
+
+    def __detect_issue(self, line: str) -> None:
+        match = re.search(r"(?i)issue(:|) (.*)", line)
+        self.__issue = f"{match.group(2)}" if match else ""
 
     @property
     def issue(self) -> str:
         """
         Issue reference should be in the footer of the commit message
         """
-        match = re.search(r"(?i)issue(:|) (.*)", self.__lines[-1])
-        return f"{match.group(2)}" if match else ""
+        return self.__issue
 
     @property
     def subject(self) -> str:
         """
         Subject is the first line of the commit message
         """
-        return self.__lines[0]
+        return self.__lines[0] if len(self.__lines) > 0 else ""
+
+    @property
+    def body(self) -> str:
+        """
+        Body is all except the first line
+        """
+        return "\n".join(self.__lines[1:]).lstrip("\n")

--- a/pull_request_codecommit/pull_request.py
+++ b/pull_request_codecommit/pull_request.py
@@ -27,9 +27,16 @@ class PullRequest:
 
     @property
     def description(self) -> str:
-        description = list(map(lambda commit: commit.message.subject, self.__commits))
+        if len(self.__commits) == 1:
+            description = (
+                [self.__commits.first.message.body] if self.__commits.first else []
+            )
+        else:
+            description = list(
+                map(lambda commit: commit.message.subject, self.__commits)
+            )
 
         if self.__commits.issues:
             description.append(f"\nIssues: " + ", ".join(self.__commits.issues))
 
-        return "\n".join(description)
+        return "\n".join(description).lstrip("\n")

--- a/tests/test_pull_request.py
+++ b/tests/test_pull_request.py
@@ -41,16 +41,20 @@ Date:   Fri Jan 21 21:01:00 2022 +0100
     "commits, expected_title, expected_description",
     [
         (Commits(COMMIT_SIMPLE_MESSAGE), "feat: my first commit", ""),
-        (Commits(COMMIT_DETAILED_MESSAGE), "feat: my first commit", ""),
+        (
+            Commits(COMMIT_DETAILED_MESSAGE),
+            "feat: my first commit",
+            "Some additional information",
+        ),
         (
             Commits(COMMIT_SIMPLE_MESSAGE_ISSUE),
             "feat: my first commit (#1)",
-            "\nIssues: #1",
+            "Issues: #1",
         ),
         (
             Commits(COMMIT_DETAILED_MESSAGE_ISSUE),
             "feat: my first commit (#1)",
-            "\nIssues: #1",
+            "Some additional information\n\nIssues: #1",
         ),
         (
             Commits(""),


### PR DESCRIPTION
**Issue #, if available:** N/A

## Description of changes:

When you have a single commit. The body might contain additional information. So we include that information in the description as a suggestion.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
