### PR TITLE
fix: compare remote branches

### DIFF
--- a/pull_request_codecommit/git/client.py
+++ b/pull_request_codecommit/git/client.py
@@ -33,14 +33,18 @@ class Client:
         return self.__execute(["branch", "--show-current"])
 
     def get_commit_messages(self, destination_branch: str) -> Commits:
+        self.fetch()
         messages = self.__execute(
-            ["log", f"origin/{destination_branch}..{self.current_branch}"]
+            ["log", f"origin/{destination_branch}..origin/{self.current_branch}"]
         )
 
         return Commits(messages)
 
     def checkout(self, destination: str) -> None:
         self.__execute(["checkout", destination])
+
+    def fetch(self) -> None:
+        self.__execute(["fetch"])
 
     def pull(self) -> None:
         self.__execute(["pull"])


### PR DESCRIPTION
**Issue #, if available:** #32, #34

## Description of changes:

In the previous release (#34) we compared the remote destination. This works fine but we should compare both repos based on the remote. The pull request is created remote so the pull request description should reflect the remote state.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
