### PR TITLE
fix: handling of aws and git failures

### DIFF
--- a/pull_request_codecommit/__init__.py
+++ b/pull_request_codecommit/__init__.py
@@ -16,13 +16,16 @@ def main(
     """
     pull-request-codecommit
     """
-    repo = __load_repository(repository_path=repository_path, target_branch=branch)
-    __display_repository_information(repo)
-    pr = __create_pull_request(repo)
+    try:
+        repo = __load_repository(repository_path=repository_path, target_branch=branch)
+        __display_repository_information(repo)
+        pr = __create_pull_request(repo)
 
-    if auto_merge:
-        status = pr.merge()
-        click.echo(f"Auto merging resulted in: {status}")
+        if auto_merge:
+            status = pr.merge()
+            click.echo(f"Auto merging resulted in: {status}")
+    except Exception as exception:
+        raise click.ClickException(str(exception))
 
 
 def __load_repository(

--- a/pull_request_codecommit/aws/client.py
+++ b/pull_request_codecommit/aws/client.py
@@ -32,7 +32,16 @@ class Client:
     def __execute(self, parameters: List[str]) -> str:
         command = self.base_command
         command.extend(parameters)
-        response = subprocess.run(command, stdout=subprocess.PIPE)
+        response = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        if response.returncode != 0:
+            message = response.stderr.decode("utf-8").strip("\n")
+            last_line = message.splitlines()[-1]
+            raise Exception(
+                f"Failed to execute: `{command}`\n\n{last_line}\n\nYou can execute the command manually to troubleshoot!"
+            )
 
         return response.stdout.decode("utf-8").strip("\n")
 


### PR DESCRIPTION
**Issue #, if available:** #26

## Description of changes:

By catching the stderr and error codes from the aws and git executions we render a proper error message.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
